### PR TITLE
fix: adjust ActivatableCollection typing so it works with async workers

### DIFF
--- a/src/activatable/activatable.ts
+++ b/src/activatable/activatable.ts
@@ -17,10 +17,13 @@
 Created with Monodraw
  */
 
-export interface IActivatable {
-  readonly state: 'deactivated' | 'isActivating' | 'activated' | 'isDeactivating';
+export interface IMinimalActivatable {
   activate: () => Promise<void>;
   deactivate: () => Promise<void>;
+}
+
+export interface IActivatable extends IMinimalActivatable {
+  readonly state: 'deactivated' | 'isActivating' | 'activated' | 'isDeactivating';
 }
 
 export abstract class Activatable implements IActivatable {
@@ -78,7 +81,7 @@ export interface IActivatableCollection extends IActivatable {
 }
 
 export class ActivatableCollection extends Activatable implements IActivatableCollection {
-  public readonly activatables: IActivatable[] = [];
+  public readonly activatables: IMinimalActivatable[] = [];
 
   protected async doActivate() {
     for (const activatable of this.activatables) {
@@ -92,7 +95,7 @@ export class ActivatableCollection extends Activatable implements IActivatableCo
     }
   }
 
-  public push(activatables: IActivatable) {
+  public push(activatables: IMinimalActivatable) {
     this.activatables.push(activatables);
   }
 }

--- a/src/activatable/activatable.ts
+++ b/src/activatable/activatable.ts
@@ -80,7 +80,8 @@ export interface IActivatableCollection extends IActivatable {
   // noop
 }
 
-export class ActivatableCollection<T extends IMinimalActivatable> extends Activatable implements IActivatableCollection {
+export class ActivatableCollection<T extends IMinimalActivatable> extends Activatable
+  implements IActivatableCollection {
   public readonly activatables: T[] = [];
 
   protected async doActivate() {

--- a/src/activatable/activatable.ts
+++ b/src/activatable/activatable.ts
@@ -80,8 +80,8 @@ export interface IActivatableCollection extends IActivatable {
   // noop
 }
 
-export class ActivatableCollection extends Activatable implements IActivatableCollection {
-  public readonly activatables: IMinimalActivatable[] = [];
+export class ActivatableCollection<T extends IMinimalActivatable> extends Activatable implements IActivatableCollection {
+  public readonly activatables: T[] = [];
 
   protected async doActivate() {
     for (const activatable of this.activatables) {
@@ -95,7 +95,7 @@ export class ActivatableCollection extends Activatable implements IActivatableCo
     }
   }
 
-  public push(activatables: IMinimalActivatable) {
+  public push(activatables: T) {
     this.activatables.push(activatables);
   }
 }


### PR DESCRIPTION
Just because you can't read its `state` synchronously shouldn't stop you from adding a worker that implements `Activatable` to an `ActivatableCollection`.