### PR TITLE
fix: make Activatable.state MobX observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,17 @@
     "test.update": "yarn test --updateSnapshot",
     "test.watch": "yarn test --watch"
   },
-  "peerDependencies": {},
+  "peerDependencies": {
+    "mobx": "~5.13"
+  },
   "dependencies": {
     "strict-event-emitter-types": "^2.0.0",
     "wolfy87-eventemitter": "5.2.6"
   },
   "devDependencies": {
     "@stoplight/scripts": "3.1.x",
-    "typescript": "3.4.5"
+    "typescript": "3.4.5",
+    "mobx": "~5.13"
   },
   "lint-staged": {
     "*.{ts,tsx}$": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,6 +8200,11 @@ mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdir
   dependencies:
     minimist "0.0.8"
 
+mobx@~5.13:
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.13.0.tgz#0fd68f10aa5ff2d146a4ed9e145b53337cfbca59"
+  integrity sha512-eSAntMSMNj0PFL705rgv+aB/z1RjNqDnFEpBe18yQVreXTWiVgIrmBUXzjnJfuba+eo4eAk6zi+/gXQkSUea8A==
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"


### PR DESCRIPTION
Use case: A React component may want to show a loading screen while 
```ts
activatable.state === 'isActivating'
```

 or show a button that is disabled unless something is active, like

```tsx
<Button disabled={activatable.state !== 'activated'}>
```

Rationale: we already have code in Studio that uses `isActivated` and `isActivating` in an observable manner. Porting that code to use `Activatable.state` without making `state` a MobX observable value would be difficult.