### PR TITLE
fix: make Activatable._state protected

### DIFF
--- a/src/activatable/activatable.ts
+++ b/src/activatable/activatable.ts
@@ -27,7 +27,7 @@ export interface IActivatable extends IMinimalActivatable {
 }
 
 export abstract class Activatable implements IActivatable {
-  private _state: 'deactivated' | 'isActivating' | 'activated' | 'isDeactivating' = 'deactivated';
+  protected _state: 'deactivated' | 'isActivating' | 'activated' | 'isDeactivating' = 'deactivated';
 
   public get state() {
     return this._state;


### PR DESCRIPTION
This makes it trivial to make a MobX-ified version

```
class Foo extends Activatable {
  @observable
  protected _state: 'activated' | 'deactivated' | 'isActivating' | 'isDeactivating' = 'deactivated';
}
```

Boom. `@stoplight/lifecycle` remains MobX free. Final implementation is way more efficient than using Event emitters, and less bug prone to write.