### PR TITLE
fix: deactivate ActivatableCollection in the correct order

### DIFF
--- a/src/activatable/__tests__/__helpers__/ThingWhereOrderMatters.ts
+++ b/src/activatable/__tests__/__helpers__/ThingWhereOrderMatters.ts
@@ -1,0 +1,13 @@
+import { Activatable } from '../..';
+
+export class ThingWhereOrderMatters extends Activatable {
+  constructor(public ordering: string[], public id: string) {
+    super();
+  }
+  protected async doActivate() {
+    this.ordering.push(this.id);
+  }
+  protected async doDeactivate() {
+    this.ordering.push(this.id);
+  }
+}

--- a/src/activatable/__tests__/activatableCollection.unit.ts
+++ b/src/activatable/__tests__/activatableCollection.unit.ts
@@ -1,4 +1,5 @@
 import { Activatable, ActivatableCollection } from '../';
+import { ThingWhereOrderMatters } from './__helpers__/ThingWhereOrderMatters';
 
 const sleep = (ms: number) => new Promise((resolve, reject) => setTimeout(resolve, ms));
 
@@ -51,6 +52,19 @@ describe('activatable collection', () => {
     expect(b.state).toEqual('deactivated');
   });
 
+  test('deactivate in reverse order of activating', async () => {
+    const activatables = new ActivatableCollection();
+    const orderDeactivated: string[] = [];
+    const a = new ThingWhereOrderMatters(orderDeactivated, 'a');
+    const b = new ThingWhereOrderMatters(orderDeactivated, 'b');
+    activatables.push(a);
+    activatables.push(b);
+
+    await activatables.activate();
+    await activatables.deactivate();
+    expect(orderDeactivated).toEqual(['a', 'b', 'b', 'a']);
+  });
+
   test('unhappy path (one item fails to activate)', async () => {
     const activatables = new ActivatableCollection();
     const a = new ThingThatDoesntFail();
@@ -70,15 +84,18 @@ describe('activatable collection', () => {
     const activatables = new ActivatableCollection();
     const a = new ThingThatDoesntFail();
     const b = new ThingThatFailsToDeactivate();
+    const c = new ThingThatDoesntFail();
     activatables.push(a);
     activatables.push(b);
+    activatables.push(c);
 
     expect(activatables.state).toBe('deactivated');
     await activatables.activate();
     const res = activatables.deactivate();
     await expect(res).rejects.toThrow('fail');
-    expect(a.state).toEqual('deactivated');
+    expect(c.state).toEqual('deactivated');
     expect(b.state).toEqual('activated');
+    expect(a.state).toEqual('activated');
     expect(activatables.state).toEqual('activated');
   });
 });

--- a/src/activatable/activatable.ts
+++ b/src/activatable/activatable.ts
@@ -91,7 +91,7 @@ export class ActivatableCollection<T extends IMinimalActivatable> extends Activa
   }
 
   protected async doDeactivate() {
-    for (const activatable of this.activatables) {
+    for (const activatable of [...this.activatables].reverse()) {
       await activatable.deactivate();
     }
   }


### PR DESCRIPTION
![image (3)](https://user-images.githubusercontent.com/587740/69389555-622f8600-0c9a-11ea-90b7-0cb7c27848b6.png)


We have some linter rule that prohibits 4 classes in a file, so I had to create another file.