### PR TITLE
fix: ActivatableCollection.activate failures should not leak activations

### DIFF
--- a/src/activatable/__tests__/activatableCollection.unit.ts
+++ b/src/activatable/__tests__/activatableCollection.unit.ts
@@ -75,7 +75,7 @@ describe('activatable collection', () => {
     expect(activatables.state).toBe('deactivated');
     const res = activatables.activate();
     await expect(res).rejects.toThrow('fail');
-    expect(a.state).toEqual('activated');
+    expect(a.state).toEqual('deactivated');
     expect(b.state).toEqual('deactivated');
     expect(activatables.state).toEqual('deactivated');
   });

--- a/src/activatable/activatable.ts
+++ b/src/activatable/activatable.ts
@@ -85,8 +85,22 @@ export class ActivatableCollection<T extends IMinimalActivatable> extends Activa
   public readonly activatables: T[] = [];
 
   protected async doActivate() {
-    for (const activatable of this.activatables) {
-      await activatable.activate();
+    const activated: T[] = [];
+    try {
+      for (const activatable of this.activatables) {
+        await activatable.activate();
+        activated.push(activatable);
+      }
+    } catch (e) {
+      activated.reverse();
+      for (const activatable of activated) {
+        try {
+          await activatable.deactivate();
+        } catch (_) {
+          // noop
+        }
+      }
+      throw e;
     }
   }
 


### PR DESCRIPTION
I yalced it into Studio and it fixed the `graphStore` `setAPIToken` setInterval leaking during `project_activate_fail` errors due to `gitStore` failing to activate. Didn't seem to cause any new problems.

I am _not_ applying the same logic to deactivation. Although that would be intuitive, I feel like _normally_ only activation involves allocations and creating event listeners, so the chances of deactivation failures creating a memory leak that could be fixed by re-activating everything is very small.