### PR TITLE
fix: EventEmitter typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "test.watch": "yarn test --watch"
   },
   "dependencies": {
-    "strict-event-emitter-types": "^2.0.0",
     "wolfy87-eventemitter": "~5.2.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7769,11 +7769,6 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
-strict-event-emitter-types@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz#05e15549cb4da1694478a53543e4e2f4abcf277f"
-  integrity sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==
-
 strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"


### PR DESCRIPTION
The typings provided by that `strict-event-emitter-types` library are such that TypeScript thinks that `emitter.on(...)` returns `this: EventEmitterInstance`. But our implementation returns `IDisposable`!!!

The type-check doesn't fail in all our project using EventEmitter mostly by virtue of the fact that EventEmitter also happens to _implement_ IDisposable. But it falls apart as soon as you (for example) update EventEmitter to return `Disposer`s and try to add the result to a `DisposerSet` - but you can't because the return typing of `on` is broken.

Anyway. I'm good enough at TypeScript now to implement the darn typings myself. We don't need no third-party module for that.

---

Technically this is a breaking change, because I am removing `createEventEmitter` which is a stupid stupid hack.
But as you can see [here](https://github.com/stoplightio/json-schema-editor/pull/87/files#diff-cfb8e44b6757fd740446e9e4486b73c1L28) where I upgraded `json-schema-editor` not to use this awful messy hack, it is extremely easy to migrate back to ye old `new EventEmitter<E>` and I'd encourage us all to fix our packages ASAP. I'm happy to do it.

---

Yalced into json-schema-editor here: https://github.com/stoplightio/json-schema-editor/pull/87
Yalced into platform here: https://github.com/stoplightio/platform-internal/pull/4132